### PR TITLE
Fix breadcrumbs

### DIFF
--- a/hpc-dotnet/breadcrumb/toc.yml
+++ b/hpc-dotnet/breadcrumb/toc.yml
@@ -1,2 +1,0 @@
-- name: Docs
-  tocHref: /

--- a/hpc-dotnet/docfx.json
+++ b/hpc-dotnet/docfx.json
@@ -43,7 +43,7 @@
       "uhfHeaderId": "MSDocsHeader-DotNet",
       "apiPlatform": "dotnet",
       "products": ["https://authoring-docs-microsoft.poolparty.biz/devrel/d49c9aea-6a06-4d9a-9432-6d0cbe9c4748"],
-      "breadcrumb_path": "~/breadcrumb/toc.yml"
+      "breadcrumb_path": "/dotnet/hpc-dotnet-breadcrumb/toc.json"
     },
     "fileMetadata": {
       "author": {

--- a/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
+++ b/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
@@ -2,6 +2,6 @@
   tocHref: /dotnet/
   topicHref: /dotnet/index
   items:
-  - name: API browser
+  - name: API browsers
     tocHref: /dotnet/
     topicHref: /dotnet/api/index

--- a/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
+++ b/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
@@ -1,0 +1,7 @@
+- name: .NET
+  tocHref: /dotnet/
+  topicHref: /dotnet/index
+  items:
+  - name: API browser
+    tocHref: /dotnet/
+    topicHref: /dotnet/api/index

--- a/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
+++ b/hpc-dotnet/hpc-dotnet-breadcrumb/toc.yml
@@ -2,6 +2,6 @@
   tocHref: /dotnet/
   topicHref: /dotnet/index
   items:
-  - name: API browsers
+  - name: API browser
     tocHref: /dotnet/
     topicHref: /dotnet/api/index


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.